### PR TITLE
Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.xcuserstate
 LYActivityIndicatorView.xcodeproj/xcuserdata/*
 
+# Swift Package Manager 
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+	name: "NKOActivityIndicatorView",
+    defaultLocalization: "en",
+	platforms: [
+        .iOS(.v8),
+        .tvOS(.v9)
+    ],
+    products: [
+        .library(name: "NKOActivityIndicatorView",
+            targets: ["NKOActivityIndicatorView"])
+    ],
+	targets: [
+        .target(
+           name: "NKOActivityIndicatorView",
+           path: "NKOActivityIndicatorView/Classes",
+           publicHeadersPath: "."
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,25 @@ A [Lyst.com](http://www.lyst.com) lookalike activity indicator for iOS.
 
 ## Installation
 
+### CocoaPods
+
 The best way to integrate NKOActivityIndicatorView in your project is with CocoaPods. You can find more info about this dependency manager [here](http://cocoapods.org). Just add the following line to your **Podfile**.
 
 ```
 pod 'NKOActivityIndicatorView'
 ```
+
+### Swift Package Manager
+
+Alternatively you can integrate directly in Xcode using Swift Package Manager. You can find more info about this dependency manager [here](https://www.swift.org/package-manager/)
+
+To integrate using Xcode:
+
+File -> Swift Packages -> Add Package Dependency
+
+Enter package URL: https://github.com/nakiostudio/NKOActivityIndicatorView
+
+See [here](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) for more info 
 
 ## How does it work
 


### PR DESCRIPTION
Hi there 👋 

We're using this component in our app but the iOS team are moving towards just using [Swift Package Manager](https://github.com/apple/swift-package-manager) for managing dependencies.

So I've added a `Package.swift` file to this library via the [initialisation steps](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#creating-a-library-package) and kept the same iOS and tvOS support as the CocoaPod spec file and updated the README file.

Note. since it's Objective-C I've needed to mention where the public header files can be found in the Package.swift file but didn't want / have to change the folder structure in any way.

I've tested integration here in a demo project https://github.com/madhikarma/NKOActivityIndicatorViewSPMDemo and everything appears to be working.

Please take a look when you can and let me know what you think.

Thank you in advance